### PR TITLE
修复 1.20.1 联机客机波形触发与发送覆盖问题

### DIFF
--- a/src/main/java/com/lumoren/dglabcraft/DGLabCraft.java
+++ b/src/main/java/com/lumoren/dglabcraft/DGLabCraft.java
@@ -39,7 +39,6 @@ public class DGLabCraft
         MinecraftForge.EVENT_BUS.register(new StatusEffectHandler());
         MinecraftForge.EVENT_BUS.register(new EnvironmentHandler());
         MinecraftForge.EVENT_BUS.register(new HeartbeatHandler());
-        MinecraftForge.EVENT_BUS.register(FadeManager.class);
     }
 
     private void commonSetup(final FMLCommonSetupEvent event)

--- a/src/main/java/com/lumoren/dglabcraft/events/DamageHandler.java
+++ b/src/main/java/com/lumoren/dglabcraft/events/DamageHandler.java
@@ -37,6 +37,8 @@ public class DamageHandler {
 
     @SubscribeEvent
     public void onPlayerTick(LivingEvent.LivingTickEvent event) {
+        if (!event.getEntity().level().isClientSide()) return;
+
         Minecraft mc = Minecraft.getInstance();
         if (!(event.getEntity() instanceof Player)) return;
         if (mc.player == null || mc.level == null) return;
@@ -73,6 +75,8 @@ public class DamageHandler {
 
     @SuppressWarnings("deprecation")
     private void cacheDamageSource(LivingDamageEvent event) {
+        if (!event.getEntity().level().isClientSide()) return;
+
         Minecraft mc = Minecraft.getInstance();
         if (!(event.getEntity() instanceof Player)) return;
         if (mc.player == null) return;

--- a/src/main/java/com/lumoren/dglabcraft/events/EnvironmentHandler.java
+++ b/src/main/java/com/lumoren/dglabcraft/events/EnvironmentHandler.java
@@ -27,6 +27,8 @@ public class EnvironmentHandler {
 
     @SubscribeEvent
     public void onPlayerTick(LivingEvent.LivingTickEvent event) {
+        if (!event.getEntity().level().isClientSide()) return;
+
         Minecraft mc = Minecraft.getInstance();
         if (!(event.getEntity() instanceof Player)) return;
         if (mc.player == null) return;

--- a/src/main/java/com/lumoren/dglabcraft/events/FadeManager.java
+++ b/src/main/java/com/lumoren/dglabcraft/events/FadeManager.java
@@ -47,6 +47,8 @@ public class FadeManager {
 
     @SubscribeEvent
     public static void onPlayerTick(LivingEvent.LivingTickEvent event) {
+        if (!event.getEntity().level().isClientSide()) return;
+
         Minecraft mc = Minecraft.getInstance();
         if (!(event.getEntity() instanceof Player)) return;
         if (mc.player == null) return;

--- a/src/main/java/com/lumoren/dglabcraft/events/HeartbeatHandler.java
+++ b/src/main/java/com/lumoren/dglabcraft/events/HeartbeatHandler.java
@@ -29,6 +29,8 @@ public class HeartbeatHandler {
 
     @SubscribeEvent
     public void onPlayerTick(LivingEvent.LivingTickEvent event) {
+        if (!event.getEntity().level().isClientSide()) return;
+
         Minecraft mc = Minecraft.getInstance();
         if (!(event.getEntity() instanceof Player)) return;
         if (mc.player == null) return;

--- a/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
+++ b/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
@@ -28,6 +28,7 @@ import java.util.TimerTask;
  */
 public class WebSocketServerManager {
     private static final Logger LOGGER = LoggerFactory.getLogger("DGLabCraft-WebSocketServer");
+    private static final long PULSE_PROTECTION_WINDOW_MS = 700L;
     private static WebSocketServerManager instance;
 
     private WebSocketServer server;
@@ -56,6 +57,8 @@ public class WebSocketServerManager {
     private double channelBIntensity = 0;
     private String channelAStatus = "Idle";
     private String channelBStatus = "Idle";
+
+    private long lastPulseSentAt = 0L;
 
     private final Gson gson = new Gson();
 
@@ -589,6 +592,11 @@ public class WebSocketServerManager {
             return;
         }
 
+        if (isPulseProtectionActive()) {
+            LOGGER.info("跳过渐变强度发送: 通道{} = {} (波形保护窗口内)", channel, intensity);
+            return;
+        }
+
         try {
             int channelNum = "A".equals(channel) ? 1 : 2;
             sendMessage("strength-" + channelNum + "+2+" + intensity);
@@ -605,6 +613,11 @@ public class WebSocketServerManager {
      */
     public void sendDualChannelStrengthOnly(int intensityA, int intensityB) {
         if (connectedClient == null || !connectedClient.isOpen()) {
+            return;
+        }
+
+        if (isPulseProtectionActive()) {
+            LOGGER.info("跳过双通道渐变强度发送: A={}, B={} (波形保护窗口内)", intensityA, intensityB);
             return;
         }
 
@@ -631,11 +644,13 @@ public class WebSocketServerManager {
 
     /**
      * 发送波形消息辅助方法
-     * 格式: pulse-A:["0A0A0A0A64646464", "1919181864646464"]
-     * 每个元素必须是 16 位大写十六进制字符串
+     * 格式: pulse-A:[0A0A0A0A64646464,1919181864646464]
+     * 保持与旧发送路径一致：数组元素不带引号
      */
     private void sendPulseMessage(String channelStr, List<String> chunk) {
-        // 将列表转换为 JSON 数组字符串 (紧凑格式，无空格)
+        markPulseSent();
+
+        // 将列表转换为协议数组字符串 (紧凑格式，无空格)
         StringBuilder hexArray = new StringBuilder("[");
         for (int i = 0; i < chunk.size(); i++) {
             if (i > 0) hexArray.append(",");
@@ -645,13 +660,21 @@ public class WebSocketServerManager {
             while (hex.length() < 16) hex = "0" + hex;
             // 截断超过 16 位的内容
             if (hex.length() > 16) hex = hex.substring(0, 16);
-            hexArray.append("\"").append(hex).append("\"");
+            hexArray.append(hex);
         }
         hexArray.append("]");
 
         // 发送消息: pulse-A:[...]
         sendMessage("pulse-" + channelStr + ":" + hexArray.toString());
         LOGGER.info("发送波形分块: pulse-{}:{}", channelStr, hexArray);
+    }
+
+    private void markPulseSent() {
+        lastPulseSentAt = System.currentTimeMillis();
+    }
+
+    private boolean isPulseProtectionActive() {
+        return System.currentTimeMillis() - lastPulseSentAt < PULSE_PROTECTION_WINDOW_MS;
     }
 
     /**


### PR DESCRIPTION
## Summary
- 将伤害、环境、心跳和 Fade 的发送路径限制在客户端侧，并移除 `FadeManager` 的重复注册，避免单人和联机场景下重复发送波形/强度消息。
- 调整 `WebSocketServerManager` 的 `pulse-*` 消息格式，与旧发送路径保持一致，避免波形数组元素被包成字符串。
- 为波形发送加入短暂保护窗口，避免 Fade 的强度更新在波形刚下发后立刻覆盖设备端的波形表现。

## Validation
- `./gradlew build`
- 单人环境实测波形与强度均正常。
- 局域网 Forge 服务器下以客机身份测试，伤害、摔落、低血量等波形均可触发。

## Risks
- 700ms 波形保护窗口会略微延后 Fade 类强度更新。
- 复杂整合包环境仍建议补一轮联机回归测试。