### PR TITLE
修复 1.20.1 iOS 设备下的波形指令格式兼容问题

### DIFF
--- a/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
+++ b/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
@@ -644,8 +644,8 @@ public class WebSocketServerManager {
 
     /**
      * 发送波形消息辅助方法
-     * 格式: pulse-A:[0A0A0A0A64646464,1919181864646464]
-     * 保持与旧发送路径一致：数组元素不带引号
+     * 格式: pulse-A:["0A0A0A0A64646464","1919181864646464"]
+     * iOS 端需要数组元素带双引号
      */
     private void sendPulseMessage(String channelStr, List<String> chunk) {
         markPulseSent();
@@ -660,7 +660,7 @@ public class WebSocketServerManager {
             while (hex.length() < 16) hex = "0" + hex;
             // 截断超过 16 位的内容
             if (hex.length() > 16) hex = hex.substring(0, 16);
-            hexArray.append(hex);
+            hexArray.append("\"").append(hex).append("\"");
         }
         hexArray.append("]");
 
@@ -719,7 +719,7 @@ public class WebSocketServerManager {
         // 发送新波形
         Map<String, String> msg = new HashMap<>();
         msg.put("type", "msg");
-        msg.put("message", "pulse-" + (channelNum == 1 ? "A" : "B") + ":[" + waveform + "]");
+        msg.put("message", "pulse-" + (channelNum == 1 ? "A" : "B") + ":[\"" + waveform + "\"]");
         msg.put("clientId", sessionId);
         msg.put("targetId", targetId != null ? targetId : "");
         connectedClient.send(gson.toJson(msg));


### PR DESCRIPTION
## Summary
- 将 1.20.1 Forge 版本中的 pulse 指令数组元素改为带双引号的字符串数组，以对齐 NeoForge 正常版本与 iOS 端的解析预期。
- 同时修正 sendPulseMessage(...) 与 sendWaveform(...) 两条发送路径，避免仅修复其中一条导致行为不一致。
- 不调整现有波形选择、发送时序、强度控制与 WebSocket 业务逻辑，仅修复 issue #6 指向的协议序列化兼容问题。

## Validation
- `./gradlew build`
- 复测日志中 `pulse-A/pulse-B` 已变为 `["..."]` 形式。
- Android 路径未见额外协议变更风险。

## Risks
- 该修复主要针对 iOS 解析兼容性，最终仍建议由 iOS 设备实机确认 issue #6 是否完全消失。