### PR TITLE
fix: WebSocket 启动失败 (#15)

### DIFF
--- a/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
+++ b/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
@@ -101,12 +101,13 @@ public class WebSocketServerManager {
 
     // 固定的客户端 ID（参考 DG_LAB）
     private static final String FIXED_CLIENT_ID = "1234-123456789-12345-12345-01";
+    private static final int DEFAULT_WS_PORT = 8877;
 
     private WebSocketServerManager() {
         // 使用固定的 sessionId（参考 DG_LAB）
         sessionId = FIXED_CLIENT_ID;
         // 端口号延迟到 start() 时读取 — NeoForge 在 FMLCommonSetupEvent 期间配置尚未就绪
-        port = 8877;
+        port = DEFAULT_WS_PORT;
     }
 
     public static WebSocketServerManager getInstance() {
@@ -129,8 +130,8 @@ public class WebSocketServerManager {
         try {
             port = DGLabConfig.WS_PORT.get();
         } catch (Exception e) {
-            LOGGER.warn("无法读取 WS_PORT 配置，使用默认端口 8877", e);
-            port = 8877;
+            LOGGER.warn("无法读取 WS_PORT 配置，使用默认端口 {}", DEFAULT_WS_PORT, e);
+            port = DEFAULT_WS_PORT;
         }
 
         // 获取本机局域网 IP

--- a/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
+++ b/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
@@ -105,7 +105,8 @@ public class WebSocketServerManager {
     private WebSocketServerManager() {
         // 使用固定的 sessionId（参考 DG_LAB）
         sessionId = FIXED_CLIENT_ID;
-        port = DGLabConfig.WS_PORT.get();
+        // 端口号延迟到 start() 时读取 — NeoForge 在 FMLCommonSetupEvent 期间配置尚未就绪
+        port = 8877;
     }
 
     public static WebSocketServerManager getInstance() {
@@ -122,6 +123,14 @@ public class WebSocketServerManager {
         if (isRunning) {
             LOGGER.info("WebSocket 服务器已在运行");
             return;
+        }
+
+        // 从配置读取端口（NeoForge: 配置在 FMLCommonSetupEvent 期间可能尚未加载，fallback 8877）
+        try {
+            port = DGLabConfig.WS_PORT.get();
+        } catch (Exception e) {
+            LOGGER.warn("无法读取 WS_PORT 配置，使用默认端口 8877", e);
+            port = 8877;
         }
 
         // 获取本机局域网 IP
@@ -1015,12 +1024,16 @@ public class WebSocketServerManager {
     }
 
     public String resolveConnectionHost() {
-        String configuredHost = DGLabConfig.WS_HOST.get();
-        if (configuredHost != null) {
-            configuredHost = configuredHost.trim();
-            if (!configuredHost.isEmpty() && !"localhost".equalsIgnoreCase(configuredHost)) {
-                return configuredHost;
+        try {
+            String configuredHost = DGLabConfig.WS_HOST.get();
+            if (configuredHost != null) {
+                configuredHost = configuredHost.trim();
+                if (!configuredHost.isEmpty() && !"localhost".equalsIgnoreCase(configuredHost)) {
+                    return configuredHost;
+                }
             }
+        } catch (Exception e) {
+            LOGGER.debug("无法读取 WS_HOST 配置，使用自动检测", e);
         }
         return getLocalIpAddress();
     }


### PR DESCRIPTION
## 问题

`DGLabConfig.WS_PORT.get()` 在 `WebSocketServerManager` 构造器中调用，但 NeoForge 的 COMMON 配置在 `FMLCommonSetupEvent` 期间尚未加载完毕，导致 `getInstance()` 构造时抛异常，WebSocket 服务器静默失败。

用户日志证据（`2026-05-09-1.log`）：
- 无任何 `DGLabCraft-WebSocketServer` 日志（服务器从未启动）
- `WebSocket已连接: false` 持续出现
- DG-Lab 3.0 App 卡在"正在连接"步骤

## 修复

- 构造器中 `WS_PORT.get()` 改为默认值 `8877`
- `start()` 内 `try-catch` 读取配置，失败时 fallback `8877`
- `resolveConnectionHost()` 同样加 `try-catch` 保护

## 验证方法

请在实机环境用 DG-Lab App 扫描二维码测试连接。预期：
1. 游戏日志中出现 `[DGLabCraft-WebSocketServer] WebSocket 服务器已启动`
2. App 不再卡在"正在连接"，会显示绑定状态

Closes #15