### PR TITLE
fix: restore Forge 1.20.1 mod constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ DGLab Craft 是一个 Minecraft 模组。它会把游戏里的受伤、低血量
 | --- | --- | --- | --- |
 | 1.18.2 | Forge 40.2.21 | `1.18.2` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.18.2) |
 | 1.19.2 | Forge 43.5.0 | `1.19.2` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.19.2) |
-| 1.20.1 | Forge 47.x | `1.20.1` | [v1.0.9](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.9-1.20.1) |
+| 1.20.1 | Forge 47.x | `1.20.1` | [v1.0.10](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.10-1.20.1) |
 | 1.21.1 | NeoForge 21.1.x | `1.21.1-NeoForge` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.21.1) |
 | 1.21.4 | NeoForge 21.4.x | `1.21.4-NeoForge` | [v1.0.7](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.7-1.21.4-NeoForge) |
 
 ### 2. 在 GitHub 下载 Mod
 
-1. 打开这个版本的 release：[`DGLabCraft-1.20.1-1.0.9.jar`](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.9-1.20.1)
+1. 打开这个版本的 release：[`DGLabCraft-1.20.1-1.0.10.jar`](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.10-1.20.1)
 2. 在页面下方找到 **Assets**。
-3. 下载 `DGLabCraft-1.20.1-1.0.9.jar`。
+3. 下载 `DGLabCraft-1.20.1-1.0.10.jar`。
 4. 不要下载 `Source code.zip` 或 `Source code.tar.gz`，那是给开发者看的源码包，直接放进游戏不会生效。
 
 也可以从项目的 [Releases 页面](https://github.com/bilbillm/DGLab-Craft/releases) 进入，按自己的 Minecraft 版本选择 release。
@@ -49,7 +49,7 @@ DGLab Craft 是一个 Minecraft 模组。它会把游戏里的受伤、低血量
 1. 用启动器创建或选择一个 Minecraft `1.20.1` 实例。
 2. 给这个实例安装 Forge `47.2.0+`。
 3. 打开实例目录里的 `mods` 文件夹。常见路径是 `.minecraft/mods`。
-4. 把刚下载的 `DGLabCraft-1.20.1-1.0.9.jar` 放进去。
+4. 把刚下载的 `DGLabCraft-1.20.1-1.0.10.jar` 放进去。
 5. 启动游戏，进入主菜单后点“模组”列表，确认能看到 `DGLab Craft`。
 
 如果你不知道实例目录在哪：在启动器里通常可以右键实例，选择“打开文件夹”或“打开游戏目录”。
@@ -87,7 +87,7 @@ DGLab Craft 是一个 Minecraft 模组。它会把游戏里的受伤、低血量
 - Minecraft `1.20.1`
 - Forge `47.2.0+`
 - Java `17`
-- Mod 版本 `1.0.9`
+- Mod 版本 `1.0.10`
 
 维护多个版本时，请优先把修复放到对应 MC 版本分支。不要把 Forge 和 NeoForge 的代码直接互相覆盖，它们的事件、注册和构建方式不完全一样。
 
@@ -109,7 +109,7 @@ cd DGLab-Craft
 | --- | --- | --- | --- |
 | 1.18.2 | Forge 40.2.21 | `1.18.2` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.18.2) |
 | 1.19.2 | Forge 43.5.0 | `1.19.2` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.19.2) |
-| 1.20.1 | Forge 47.x | `1.20.1` | [v1.0.9](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.9-1.20.1) |
+| 1.20.1 | Forge 47.x | `1.20.1` | [v1.0.10](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.10-1.20.1) |
 | 1.21.1 | NeoForge 21.1.x | `1.21.1-NeoForge` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.21.1) |
 | 1.21.4 | NeoForge 21.4.x | `1.21.4-NeoForge` | [v1.0.7](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.7-1.21.4-NeoForge) |
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -31,15 +31,15 @@ If your Minecraft version is different, use the matching branch and release belo
 | --- | --- | --- | --- |
 | 1.18.2 | Forge 40.2.21 | `1.18.2` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.18.2) |
 | 1.19.2 | Forge 43.5.0 | `1.19.2` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.19.2) |
-| 1.20.1 | Forge 47.x | `1.20.1` | [v1.0.9](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.9-1.20.1) |
+| 1.20.1 | Forge 47.x | `1.20.1` | [v1.0.10](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.10-1.20.1) |
 | 1.21.1 | NeoForge 21.1.x | `1.21.1-NeoForge` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.21.1) |
 | 1.21.4 | NeoForge 21.4.x | `1.21.4-NeoForge` | [v1.0.7](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.7-1.21.4-NeoForge) |
 
 ### 2. Download the Mod from GitHub
 
-1. Open this release: [`DGLabCraft-1.20.1-1.0.9.jar`](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.9-1.20.1)
+1. Open this release: [`DGLabCraft-1.20.1-1.0.10.jar`](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.10-1.20.1)
 2. Scroll to **Assets**.
-3. Download `DGLabCraft-1.20.1-1.0.9.jar`.
+3. Download `DGLabCraft-1.20.1-1.0.10.jar`.
 4. Do not download `Source code.zip` or `Source code.tar.gz` for normal play. Those are source packages for developers and will not work as a mod jar.
 
 You can also start from the project [Releases page](https://github.com/bilbillm/DGLab-Craft/releases) and choose the release that matches your Minecraft version.
@@ -49,7 +49,7 @@ You can also start from the project [Releases page](https://github.com/bilbillm/
 1. Create or select a Minecraft `1.20.1` instance in your launcher.
 2. Install Forge `47.2.0+` for that instance.
 3. Open the instance's `mods` folder. A common path is `.minecraft/mods`.
-4. Put `DGLabCraft-1.20.1-1.0.9.jar` into that folder.
+4. Put `DGLabCraft-1.20.1-1.0.10.jar` into that folder.
 5. Start the game and check the Mods screen for `DGLab Craft`.
 
 If you cannot find the instance folder, most launchers provide an “Open Folder” or “Open Game Directory” action for each instance.
@@ -87,7 +87,7 @@ This branch maintains:
 - Minecraft `1.20.1`
 - Forge `47.2.0+`
 - Java `17`
-- Mod version `1.0.9`
+- Mod version `1.0.10`
 
 When maintaining multiple versions, put fixes on the matching Minecraft branch first. Do not blindly copy Forge and NeoForge code between branches because their events, registration APIs, and build flows differ.
 
@@ -109,7 +109,7 @@ For release uploads, use the full jar, normally the one without `-slim` in its f
 | --- | --- | --- | --- |
 | 1.18.2 | Forge 40.2.21 | `1.18.2` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.18.2) |
 | 1.19.2 | Forge 43.5.0 | `1.19.2` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.19.2) |
-| 1.20.1 | Forge 47.x | `1.20.1` | [v1.0.9](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.9-1.20.1) |
+| 1.20.1 | Forge 47.x | `1.20.1` | [v1.0.10](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.10-1.20.1) |
 | 1.21.1 | NeoForge 21.1.x | `1.21.1-NeoForge` | [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.21.1) |
 | 1.21.4 | NeoForge 21.4.x | `1.21.4-NeoForge` | [v1.0.7](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.7-1.21.4-NeoForge) |
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 # DGLab Craft Changelog
 
+## [1.0.10] - 2026-06-18
+
+### 修复
+- 修复 Minecraft 1.20.1 / Forge 47.2.0 下主 Mod 类缺少无参构造器导致加载失败的问题。
+- 新增回归测试，确认 Forge 能通过反射找到 `DGLabCraft()` 构造器。
+
+---
+
 ## [1.0.8-beta] - 2026-05-12
 
 > ⚠️ **此为 Beta 版本，未经实机测试。** 包含架构加固（线程安全、资源清理、死代码删除）、75 个单元测试和日志规范化改动。如需稳定版本请使用 [v1.0.6](https://github.com/bilbillm/DGLab-Craft/releases/tag/v1.0.6-1.20.1)。

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=DGLab Craft
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GPL-3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.9
+mod_version=1.0.10
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/lumoren/dglabcraft/DGLabCraft.java
+++ b/src/main/java/com/lumoren/dglabcraft/DGLabCraft.java
@@ -1,6 +1,5 @@
 package com.lumoren.dglabcraft;
 
-import com.lumoren.dglabcraft.config.ModConfig;
 import com.lumoren.dglabcraft.events.DamageHandler;
 import com.lumoren.dglabcraft.events.EnvironmentHandler;
 import com.lumoren.dglabcraft.events.HeartbeatHandler;
@@ -10,19 +9,19 @@ import net.minecraft.client.Minecraft;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fml.ModLoadingContext;
 
 @Mod(DGLabCraft.MODID)
 public class DGLabCraft
 {
     public static final String MODID = "dglabcraft";
 
-    public DGLabCraft(FMLJavaModLoadingContext context)
+    public DGLabCraft()
     {
-        IEventBus modEventBus = context.getModEventBus();
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
 
         // 注册通用设置
         modEventBus.addListener(this::commonSetup);

--- a/src/test/java/com/lumoren/dglabcraft/DGLabCraftTest.java
+++ b/src/test/java/com/lumoren/dglabcraft/DGLabCraftTest.java
@@ -1,0 +1,13 @@
+package com.lumoren.dglabcraft;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class DGLabCraftTest {
+
+    @Test
+    void forgeCanFindNoArgModConstructor() {
+        assertDoesNotThrow(() -> DGLabCraft.class.getDeclaredConstructor());
+    }
+}


### PR DESCRIPTION
## Summary
- Restore the Forge 1.20.1 no-arg mod constructor so Forge can instantiate the mod class.
- Keep mod event bus registration via FMLJavaModLoadingContext.get().
- Add a regression test that verifies the no-arg constructor is discoverable by reflection.

## Review
- Checked the constructor change against Forge 1.20.1 registration expectations.
- Verified the PR branch is based on current origin/1.20.1 and contains only this fix.

## Tests
- ./gradlew.bat test