### PR TITLE
fix: delay NeoForge WebSocket config reads

### DIFF
--- a/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
+++ b/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
@@ -101,12 +101,13 @@ public class WebSocketServerManager {
 
     // 固定的客户端 ID（参考 DG_LAB）
     private static final String FIXED_CLIENT_ID = "1234-123456789-12345-12345-01";
+    private static final int DEFAULT_WS_PORT = 8877;
 
     private WebSocketServerManager() {
         // 使用固定的 sessionId（参考 DG_LAB）
         sessionId = FIXED_CLIENT_ID;
         // 端口号延迟到 start() 时读取 — NeoForge 在 FMLCommonSetupEvent 期间配置尚未就绪
-        port = 8877;
+        port = DEFAULT_WS_PORT;
     }
 
     public static WebSocketServerManager getInstance() {
@@ -129,8 +130,8 @@ public class WebSocketServerManager {
         try {
             port = DGLabConfig.WS_PORT.get();
         } catch (Exception e) {
-            LOGGER.warn("无法读取 WS_PORT 配置，使用默认端口 8877", e);
-            port = 8877;
+            LOGGER.warn("无法读取 WS_PORT 配置，使用默认端口 {}", DEFAULT_WS_PORT, e);
+            port = DEFAULT_WS_PORT;
         }
 
         // 获取本机局域网 IP

--- a/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
+++ b/src/main/java/com/lumoren/dglabcraft/network/WebSocketServerManager.java
@@ -105,7 +105,8 @@ public class WebSocketServerManager {
     private WebSocketServerManager() {
         // 使用固定的 sessionId（参考 DG_LAB）
         sessionId = FIXED_CLIENT_ID;
-        port = DGLabConfig.WS_PORT.get();
+        // 端口号延迟到 start() 时读取 — NeoForge 在 FMLCommonSetupEvent 期间配置尚未就绪
+        port = 8877;
     }
 
     public static WebSocketServerManager getInstance() {
@@ -122,6 +123,14 @@ public class WebSocketServerManager {
         if (isRunning) {
             LOGGER.info("WebSocket 服务器已在运行");
             return;
+        }
+
+        // 从配置读取端口（NeoForge: 配置在 FMLCommonSetupEvent 期间可能尚未加载，fallback 8877）
+        try {
+            port = DGLabConfig.WS_PORT.get();
+        } catch (Exception e) {
+            LOGGER.warn("无法读取 WS_PORT 配置，使用默认端口 8877", e);
+            port = 8877;
         }
 
         // 获取本机局域网 IP
@@ -1015,12 +1024,16 @@ public class WebSocketServerManager {
     }
 
     public String resolveConnectionHost() {
-        String configuredHost = DGLabConfig.WS_HOST.get();
-        if (configuredHost != null) {
-            configuredHost = configuredHost.trim();
-            if (!configuredHost.isEmpty() && !"localhost".equalsIgnoreCase(configuredHost)) {
-                return configuredHost;
+        try {
+            String configuredHost = DGLabConfig.WS_HOST.get();
+            if (configuredHost != null) {
+                configuredHost = configuredHost.trim();
+                if (!configuredHost.isEmpty() && !"localhost".equalsIgnoreCase(configuredHost)) {
+                    return configuredHost;
+                }
             }
+        } catch (Exception e) {
+            LOGGER.debug("无法读取 WS_HOST 配置，使用自动检测", e);
         }
         return getLocalIpAddress();
     }


### PR DESCRIPTION
## Summary
- Delay NeoForge WebSocket config reads until start(), when config is available.
- Fall back to the default WebSocket port when config access fails during early startup.
- Guard manual host resolution so config access failures still fall back to LAN IP detection.

## Review
- Checked that constructor initialization no longer touches DGLabConfig.WS_PORT.
- Confirmed the branch diff against current origin/1.21.1-NeoForge only changes WebSocketServerManager.
- This reapplies the fix from #15 because the current maintenance branch does not contain those commits.

## Tests
- ./gradlew.bat test (first run completed NeoForge artifact generation; second run succeeded, test task had NO-SOURCE)